### PR TITLE
PRSEC-2439 Remove secrets from logged presigned URLs

### DIFF
--- a/client.go
+++ b/client.go
@@ -910,16 +910,16 @@ func (c *Client) StandardClient() *http.Client {
 	}
 }
 
-// Taken from url.URL#Redacted() which was introduced in go 1.15.
-// We can switch to using it directly if we'll bump the minimum required go version.
+// Should be aligned with wiz-sec/wiz/commonlib/anonymize/anonymize.go#RedactURL()
 func redactURL(u *url.URL) string {
 	if u == nil {
 		return ""
 	}
 
 	ru := *u
-	if _, has := ru.User.Password(); has {
-		ru.User = url.UserPassword(ru.User.Username(), "xxxxx")
-	}
-	return ru.String()
+
+	// Remove query as it might contain secrets, e.g. presigned URLs
+	ru.RawQuery = ""
+	ru.ForceQuery = false
+	return ru.Redacted()
 }


### PR DESCRIPTION
Remove secrets from URLs when logging.

We use `go-retryablehttp` when uploading data to presigned URLs and retries are logging the URLs.

Before:
```
time=2025-07-06T21:56:49.423+03:00 level=DEBUG msg="retrying request" request="GET http://127.0.0.1:61087?X-Amz-Credential=SECRET&X-Amz-Signature=SECRET&X-Amz-Security-Token=SECRET (status: 500)" timeout=1s remaining=4
```

After:
```
time=2025-07-06T21:55:37.272+03:00 level=DEBUG msg="retrying request" request="GET http://127.0.0.1:61004 (status: 500)" timeout=1s remaining=4
```